### PR TITLE
Expand carry over feature from yesterday to the past incomplete tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,11 @@ Initial release: Briefing, Focus, Done views, and carry over feature.
 Update README
 - Changed sample image size
 - Add note for keeping the **Today-ToDo** icon on the side bar.
+
+## [0.0.3] - 2026-02-11
+### Feat
+- Expanded carry over feature to include all past incomplete tasks, not just yesterday's
+- Renamed `pastTask` to `latestIncompleteTask` for better code clarity
+
+### Refactor
+- Improved terminology consistency across codebase

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This simple workflow helps you stay focused and productive, one day at a time.
 
 ## Features
 - 📋 Briefing: Add today's tasks and select up to 3 to focus on
-- ⚠️ Yesterday's incomplete tasks: Carry over unfinished tasks with one click
+- ⚠️ Past incomplete tasks: Carry over unfinished tasks from any past session with one click
 - 🎯 Focus Mode: Check off tasks as you complete them
 - ✅ Done Today / Done All: Review your completed tasks by day or all-time
 - 🌓 Theme-aware: Seamlessly matches your VS Code theme

--- a/core/commands/carryOverTask.ts
+++ b/core/commands/carryOverTask.ts
@@ -3,18 +3,21 @@ import type { Task } from '../domain/types';
 import { generateUUID } from '../utils/uuid';
 
 /**
- * Carry Over Past Incomplete Tasks to Today
+ * Carry Over Latest Incomplete Tasks to Today
  */
-export async function carryOverTask(pastTask: Task, storage: StorageAdapter): Promise<Task> {
+export async function carryOverTask(
+  latestIncompleteTask: Task,
+  storage: StorageAdapter,
+): Promise<Task> {
   const session = await storage.getTodaySessions();
   if (!session) {
     throw new Error('No active today session found.');
   }
 
-  // Create a new task for today based on past incomplete task
+  // Create a new task for today based on latest incomplete task
   const newTask: Task = {
     id: generateUUID(),
-    title: pastTask.title,
+    title: latestIncompleteTask.title,
     isDone: false,
     createdAt: new Date(),
     doneAt: null,
@@ -27,10 +30,10 @@ export async function carryOverTask(pastTask: Task, storage: StorageAdapter): Pr
   session.todayListTaskIds.push(newTask.id);
   await storage.saveTodaySessions(session);
 
-  // Mark the original past task as done
-  pastTask.isDone = true;
-  pastTask.doneAt = new Date();
-  await storage.updateArchivedTasks(pastTask);
+  // Mark the original latest incomplete task as done
+  latestIncompleteTask.isDone = true;
+  latestIncompleteTask.doneAt = new Date();
+  await storage.updateArchivedTasks(latestIncompleteTask);
 
   return newTask;
 }

--- a/core/commands/carryOverTask.ts
+++ b/core/commands/carryOverTask.ts
@@ -1,21 +1,20 @@
 import type { StorageAdapter } from '../storage/StorageAdapter';
 import type { Task } from '../domain/types';
 import { generateUUID } from '../utils/uuid';
-import { computeLogicalDate } from '../utils/logicalDate';
 
 /**
- * Carry Over Yesterday's Incomplete Tasks to Today
+ * Carry Over Past Incomplete Tasks to Today
  */
-export async function carryOverTask(yesterdayTask: Task, storage: StorageAdapter): Promise<Task> {
+export async function carryOverTask(pastTask: Task, storage: StorageAdapter): Promise<Task> {
   const session = await storage.getTodaySessions();
   if (!session) {
     throw new Error('No active today session found.');
   }
 
-  // Create a new task for today based on yesterday's incomplete task
+  // Create a new task for today based on past incomplete task
   const newTask: Task = {
     id: generateUUID(),
-    title: yesterdayTask.title,
+    title: pastTask.title,
     isDone: false,
     createdAt: new Date(),
     doneAt: null,
@@ -28,13 +27,10 @@ export async function carryOverTask(yesterdayTask: Task, storage: StorageAdapter
   session.todayListTaskIds.push(newTask.id);
   await storage.saveTodaySessions(session);
 
-  // Mark the original yesterday task as done
-  const yesterday = new Date();
-  yesterday.setDate(yesterday.getDate() - 1);
-  const yesterdayLogicalDate = computeLogicalDate(yesterday);
-  yesterdayTask.isDone = true;
-  yesterdayTask.doneAt = new Date();
-  await storage.updateArchivedTasks(yesterdayLogicalDate, yesterdayTask);
+  // Mark the original past task as done
+  pastTask.isDone = true;
+  pastTask.doneAt = new Date();
+  await storage.updateArchivedTasks(pastTask);
 
   return newTask;
 }

--- a/core/storage/StorageAdapter.ts
+++ b/core/storage/StorageAdapter.ts
@@ -29,8 +29,8 @@ export interface StorageAdapter {
 
   // Archived Task related methods
   getArchivedTasks(logicalDate?: string): Promise<Task[]>;
-  getYesterdayIncompleteTasks(): Promise<Task[]>;
-  updateArchivedTasks(logicalDate: string, task: Task): Promise<void>;
+  updateArchivedTasks(task: Task, logicalDate?: string): Promise<void>;
+  getLatestIncompleteTasks(): Promise<Task[]>;
 
   // All tasks
   getAllTasks(): Promise<Task[]>;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "today-todo",
   "displayName": "Today-ToDo",
   "description": "Focus on today, Make progress.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publisher": "k2-gc",
   "icon": "media/icon.png",
   "engines": {

--- a/src/AppController.ts
+++ b/src/AppController.ts
@@ -115,10 +115,10 @@ export class AppController {
   }
 
   /**
-   * Carry over past incomplete task to today.
+   * Carry over latest incomplete task to today.
    */
-  async carryOverTask(pastTask: Task): Promise<Task> {
-    return await carryOverTask(pastTask, this.storage);
+  async carryOverTask(latestIncompleteTask: Task): Promise<Task> {
+    return await carryOverTask(latestIncompleteTask, this.storage);
   }
 
   /**

--- a/src/AppController.ts
+++ b/src/AppController.ts
@@ -108,17 +108,17 @@ export class AppController {
   }
 
   /**
-   * Obtain yesterday's incomplete tasks.
+   * Obtain latest incomplete tasks.
    */
-  async getYesterdayIncompleteTasks(): Promise<Task[]> {
-    return await this.storage.getYesterdayIncompleteTasks();
+  async getLatestIncompleteTasks(): Promise<Task[]> {
+    return await this.storage.getLatestIncompleteTasks();
   }
 
   /**
-   * Carry over yesterday's incomplete task to today.
+   * Carry over past incomplete task to today.
    */
-  async carryOverTask(yesterdayTask: Task): Promise<Task> {
-    return await carryOverTask(yesterdayTask, this.storage);
+  async carryOverTask(pastTask: Task): Promise<Task> {
+    return await carryOverTask(pastTask, this.storage);
   }
 
   /**

--- a/src/storage/VSCodeStorageAdapter.ts
+++ b/src/storage/VSCodeStorageAdapter.ts
@@ -179,16 +179,70 @@ export class VSCodeStorageAdapter implements StorageAdapter {
     }
   }
 
-  async getYesterdayIncompleteTasks(): Promise<Task[]> {
+  async updateArchivedTasks(task: Task, logicalDate?: string): Promise<void> {
     try {
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
-      const yesterdayLogicalDate = computeLogicalDate(yesterday);
+      await fs.access(this.archiveDir.fsPath);
+    } catch (error) {
+      throw new Error('Archive directory does not exist');
+    }
 
-      const archiveFile = vscode.Uri.joinPath(this.archiveDir, `${yesterdayLogicalDate}.json`);
-      if (!(await fs.stat(archiveFile.fsPath).catch(() => false))) {
-        return [];
+    let targetDate = logicalDate;
+    // If no logicalDate specified, find the archive containing this task
+    if (!targetDate) {
+      const files = await fs.readdir(this.archiveDir.fsPath);
+      const archiveFiles = files
+        .filter((file: string) => file.endsWith('.json'))
+        .sort()
+        .reverse();
+
+      for (const file of archiveFiles) {
+        const archiveFile = vscode.Uri.joinPath(this.archiveDir, file);
+        const data = await fs.readFile(archiveFile.fsPath, 'utf-8');
+        const parsed: StorageData = JSON.parse(data);
+
+        if (parsed.tasks.some((t) => t.id === task.id)) {
+          targetDate = path.basename(file, '.json');
+          break;
+        }
       }
+      if (!targetDate) {
+        throw new Error(`Task ${task.id} not found in any archive`);
+      }
+    }
+
+    const archiveFile = vscode.Uri.joinPath(this.archiveDir, `${targetDate}.json`);
+    const data = await fs.readFile(archiveFile.fsPath, 'utf-8');
+    const parsed: StorageData = JSON.parse(data);
+
+    const index = parsed.tasks.findIndex((t) => t.id === task.id);
+    if (index !== -1) {
+      parsed.tasks[index] = task;
+      await fs.writeFile(archiveFile.fsPath, JSON.stringify(parsed, null, 2), 'utf-8');
+    } else {
+      throw new Error(`Task ${task.id} not found in archive ${targetDate}`);
+    }
+  }
+
+  async getLatestIncompleteTasks(): Promise<Task[]> {
+    try {
+      await fs.access(this.archiveDir.fsPath);
+    } catch (error) {
+      return [];
+    }
+
+    const files = await fs.readdir(this.archiveDir.fsPath);
+    const archiveFiles = files
+      .filter((file: string) => file.endsWith('.json'))
+      .sort()
+      .reverse();
+
+    if (archiveFiles.length === 0) {
+      return [];
+    }
+
+    // Search for the most recent archive with incomplete tasks
+    for (const file of archiveFiles) {
+      const archiveFile = vscode.Uri.joinPath(this.archiveDir, file);
       const data = await fs.readFile(archiveFile.fsPath, 'utf-8');
       const parsed: StorageData = JSON.parse(data);
       const incompleteTasks = parsed.tasks
@@ -198,29 +252,14 @@ export class VSCodeStorageAdapter implements StorageAdapter {
           createdAt: new Date(task.createdAt),
           doneAt: task.doneAt ? new Date(task.doneAt) : null,
         }));
-      return incompleteTasks;
-    } catch (error) {
-      console.error('Failed to get yesterday incomplete tasks:', error);
-      return [];
-    }
-  }
 
-  async updateArchivedTasks(logicalDate: string, task: Task): Promise<void> {
-    try {
-      const archiveFile = vscode.Uri.joinPath(this.archiveDir, `${logicalDate}.json`);
-
-      const data = await fs.readFile(archiveFile.fsPath, 'utf-8');
-      const parsed: StorageData = JSON.parse(data);
-
-      const index = parsed.tasks.findIndex((t) => t.id === task.id);
-      if (index !== -1) {
-        parsed.tasks[index] = task;
-        await fs.writeFile(archiveFile.fsPath, JSON.stringify(parsed, null, 2), 'utf-8');
+      if (incompleteTasks.length > 0) {
+        return incompleteTasks;
       }
-    } catch (error) {
-      console.error('Failed to update archived tasks:', error);
     }
+    return [];
   }
+
   // All tasks
   async getAllTasks(): Promise<Task[]> {
     const todayTasks = await this.loadData();

--- a/src/webview/WebviewProvider.ts
+++ b/src/webview/WebviewProvider.ts
@@ -85,11 +85,11 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
           case 'switchView':
             await this._handleSwitchView(message.view);
             break;
-          case 'getYesterdayIncompleteTasks':
-            await this._handleGetYesterdayIncompleteTasks();
+          case 'getLatestIncompleteTasks':
+            await this._handleGetLatestIncompleteTasks();
             break;
           case 'carryOverTask':
-            await this._handleCarryOverTask(message.yesterdayTask);
+            await this._handleCarryOverTask(message.pastTask);
             break;
           case 'update':
             await this._handleUpdate();
@@ -108,13 +108,13 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
   }
 
   /**
-   * Handle getYesterdayIncompleteTasks command.
+   * Handle getLatestIncompleteTasks command.
    */
-  private async _handleGetYesterdayIncompleteTasks() {
-    const tasks = await this._appController.getYesterdayIncompleteTasks();
+  private async _handleGetLatestIncompleteTasks() {
+    const tasks = await this._appController.getLatestIncompleteTasks();
 
     this._postMessage({
-      type: 'yesterdayIncompleteTasks',
+      type: 'latestIncompleteTasks',
       payload: {
         tasks,
       },
@@ -124,8 +124,8 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
   /**
    * Handle carryOverTask command.
    */
-  private async _handleCarryOverTask(yesterdayTask: Task) {
-    const newTask = await this._appController.carryOverTask(yesterdayTask);
+  private async _handleCarryOverTask(pastTask: Task) {
+    const newTask = await this._appController.carryOverTask(pastTask);
     const session = await this._appController.getCurrentSession();
 
     this._postMessage({
@@ -133,7 +133,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
       payload: {
         task: newTask,
         session,
-        originalTaskId: yesterdayTask.id,
+        originalTaskId: pastTask.id,
       },
     });
   }

--- a/src/webview/WebviewProvider.ts
+++ b/src/webview/WebviewProvider.ts
@@ -89,7 +89,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
             await this._handleGetLatestIncompleteTasks();
             break;
           case 'carryOverTask':
-            await this._handleCarryOverTask(message.pastTask);
+            await this._handleCarryOverTask(message.latestIncompleteTask);
             break;
           case 'update':
             await this._handleUpdate();
@@ -124,8 +124,8 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
   /**
    * Handle carryOverTask command.
    */
-  private async _handleCarryOverTask(pastTask: Task) {
-    const newTask = await this._appController.carryOverTask(pastTask);
+  private async _handleCarryOverTask(latestIncompleteTask: Task) {
+    const newTask = await this._appController.carryOverTask(latestIncompleteTask);
     const session = await this._appController.getCurrentSession();
 
     this._postMessage({
@@ -133,7 +133,7 @@ export class WebviewProvider implements vscode.WebviewViewProvider {
       payload: {
         task: newTask,
         session,
-        originalTaskId: pastTask.id,
+        originalTaskId: latestIncompleteTask.id,
       },
     });
   }

--- a/src/webview/type.ts
+++ b/src/webview/type.ts
@@ -6,6 +6,6 @@ export type WebviewMessage =
   | { command: 'setFocusedTasks'; taskIds: string[] }
   | { command: 'toggleDone'; taskId: string }
   | { command: 'switchView'; view: ViewType }
-  | { command: 'getYesterdayIncompleteTasks' }
-  | { command: 'carryOverTask'; yesterdayTask: Task }
+  | { command: 'getLatestIncompleteTasks' }
+  | { command: 'carryOverTask'; pastTask: Task }
   | { command: 'update' };

--- a/src/webview/type.ts
+++ b/src/webview/type.ts
@@ -7,5 +7,5 @@ export type WebviewMessage =
   | { command: 'toggleDone'; taskId: string }
   | { command: 'switchView'; view: ViewType }
   | { command: 'getLatestIncompleteTasks' }
-  | { command: 'carryOverTask'; pastTask: Task }
+  | { command: 'carryOverTask'; latestIncompleteTask: Task }
   | { command: 'update' };

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -14,7 +14,7 @@ export default function App() {
   const [session, setSession] = useState<TodaySession | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [allTasks, setAllTasks] = useState<Task[]>([]);
-  const [yesterdayTasks, setYesterdayTasks] = useState<Task[]>([]);
+  const [latestIncompleteTasks, setLatestIncompleteTasks] = useState<Task[]>([]);
   const [doneTodayTasks, setDoneTodayTasks] = useState<Task[]>([]);
   const [doneAllTasks, setDoneAllTasks] = useState<Task[]>([]);
 
@@ -68,14 +68,14 @@ export default function App() {
           }
           break;
 
-        case 'yesterdayIncompleteTasks':
-          setYesterdayTasks(message.payload.tasks);
+        case 'latestIncompleteTasks':
+          setLatestIncompleteTasks(message.payload.tasks);
           break;
 
         case 'carryOverTask':
           setTasks((prev) => [...prev, message.payload.task]);
           setSession(message.payload.session);
-          setYesterdayTasks((prev) =>
+          setLatestIncompleteTasks((prev) =>
             prev.filter((task) => task.id !== message.payload.originalTaskId),
           );
           break;
@@ -117,12 +117,12 @@ export default function App() {
     sendMessage({ command: 'switchView', view });
   };
 
-  const handleGetYesterdayIncompleteTasks = () => {
-    sendMessage({ command: 'getYesterdayIncompleteTasks' });
+  const handleGetLatestIncompleteTasks = () => {
+    sendMessage({ command: 'getLatestIncompleteTasks' });
   };
 
   const handleCarryOverTask = (task: Task) => {
-    sendMessage({ command: 'carryOverTask', yesterdayTask: task });
+    sendMessage({ command: 'carryOverTask', pastTask: task });
   };
 
   // Get Task of Today List
@@ -143,9 +143,9 @@ export default function App() {
           tasks={todayTasks}
           onAddTask={handleAddTask}
           onSetFocusedTasks={handleSetFocusedTasks}
-          onGetYesterdayIncompleteTasks={handleGetYesterdayIncompleteTasks}
+          onGetLatestIncompleteTasks={handleGetLatestIncompleteTasks}
           onCarryOverTask={handleCarryOverTask}
-          yesterdayTasks={yesterdayTasks}
+          latestIncompleteTasks={latestIncompleteTasks}
         />
       )}
       {view === 'focus' && <FocusView tasks={focusedTasks} onToggleDone={handleToggleDone} />}

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -122,7 +122,7 @@ export default function App() {
   };
 
   const handleCarryOverTask = (task: Task) => {
-    sendMessage({ command: 'carryOverTask', pastTask: task });
+    sendMessage({ command: 'carryOverTask', latestIncompleteTask: task });
   };
 
   // Get Task of Today List

--- a/webview-ui/src/components/BriefingView.tsx
+++ b/webview-ui/src/components/BriefingView.tsx
@@ -6,25 +6,25 @@ interface BriefingViewProps {
   tasks: Task[];
   onAddTask: (title: string) => void;
   onSetFocusedTasks: (taskIds: string[]) => void;
-  onGetYesterdayIncompleteTasks: () => void;
+  onGetLatestIncompleteTasks: () => void;
   onCarryOverTask: (task: Task) => void;
-  yesterdayTasks: Task[];
+  latestIncompleteTasks: Task[];
 }
 
 export default function BriefingView({
   tasks,
   onAddTask,
   onSetFocusedTasks,
-  onGetYesterdayIncompleteTasks,
+  onGetLatestIncompleteTasks,
   onCarryOverTask,
-  yesterdayTasks,
+  latestIncompleteTasks,
 }: BriefingViewProps) {
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [selectedTaskIds, setSelectedTaskIds] = useState<string[]>([]);
-  const [showYesterday, setShowYesterday] = useState(false);
+  const [showLatestIncomplete, setShowLatestIncomplete] = useState(false);
 
   useEffect(() => {
-    onGetYesterdayIncompleteTasks();
+    onGetLatestIncompleteTasks();
   }, []);
 
   useEffect(() => {
@@ -63,16 +63,20 @@ export default function BriefingView({
     <div className="briefing-view">
       <h2>📋 Today's Briefing</h2>
 
-      {yesterdayTasks.length > 0 && (
-        <div className="yesterday-section">
-          <button className="yesterday-toggle" onClick={() => setShowYesterday(!showYesterday)}>
-            ⚠️ {yesterdayTasks.length} task{yesterdayTasks.length > 1 ? 's' : ''} from yesterday
+      {latestIncompleteTasks.length > 0 && (
+        <div className="latest-incomplete-section">
+          <button
+            className="latest-incomplete-toggle"
+            onClick={() => setShowLatestIncomplete(!showLatestIncomplete)}
+          >
+            ⚠️ {latestIncompleteTasks.length} task{latestIncompleteTasks.length > 1 ? 's' : ''} from
+            the past day
           </button>
 
-          {showYesterday && (
-            <div className="yesterday-tasks">
-              {yesterdayTasks.map((task) => (
-                <div key={task.id} className="yesterday-task-item">
+          {showLatestIncomplete && (
+            <div className="latest-incomplete-tasks">
+              {latestIncompleteTasks.map((task) => (
+                <div key={task.id} className="latest-incomplete-task-item">
                   <span className="task-title">{task.title}</span>
                   <button className="carry-over-button" onClick={() => handleCarryOver(task)}>
                     Carry Over

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -118,7 +118,7 @@ input {
   opacity: 0.7;
 }
 
-.yesterday-section {
+.latest-incomplete-section {
   margin-bottom: 20px;
   padding: 12px;
   background-color: var(--vscode-inputValidation-warningBackground);
@@ -126,7 +126,7 @@ input {
   border-radius: 4px;
 }
 
-.yesterday-toggle {
+.latest-incomplete-toggle {
   width: 100%;
   text-align: left;
   padding: 8px;
@@ -137,16 +137,16 @@ input {
   font-weight: 500;
 }
 
-.yesterday-toggle:hover {
+.latest-incomplete-toggle:hover {
   background-color: var(--vscode-list-hoverBackground);
 }
 
-.yesterday-tasks {
+.latest-incomplete-tasks {
   margin-top: 12px;
   padding-left: 8px;
 }
 
-.yesterday-task-item {
+.latest-incomplete-task-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -156,7 +156,7 @@ input {
   border-radius: 2px;
 }
 
-.yesterday-task-item .task-title {
+.latest-incomplete-task-item .task-title {
   flex: 1;
   opacity: 0.8;
 }


### PR DESCRIPTION
## Expand carry over feature from yesterday to the past incomplete tasks

### What changed
- Users can now carry over incomplete tasks from **latest incomplete session**, not just yesterday
- Renamed `pastTask` to `latestIncompleteTask` for code clarity

### Why
- Makes it easier to recover forgotten tasks from older sessions
- Improves code readability and maintainability

/close #4 