### PR TITLE
Fixed bug where carry-over tasks incorrectly appeared in all done list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,7 @@ Update README
 
 ### Refactor
 - Improved terminology consistency across codebase
+
+## [0.0.4] - 2026-02-19
+### Fix
+- Prevented carry-over tasks from appearing in all done list

--- a/core/commands/carryOverTask.ts
+++ b/core/commands/carryOverTask.ts
@@ -30,9 +30,11 @@ export async function carryOverTask(
   session.todayListTaskIds.push(newTask.id);
   await storage.saveTodaySessions(session);
 
-  // Mark the original latest incomplete task as done
+  // Mark the original latest incomplete task as done (but not as "completed")
+  // This is a carry-over, not a real completion, so we don't set doneSessionId
   latestIncompleteTask.isDone = true;
   latestIncompleteTask.doneAt = new Date();
+  latestIncompleteTask.doneSessionId = null;
   await storage.updateArchivedTasks(latestIncompleteTask);
 
   return newTask;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "today-todo",
   "displayName": "Today-ToDo",
   "description": "Focus on today, Make progress.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "k2-gc",
   "icon": "media/icon.png",
   "engines": {

--- a/src/AppController.ts
+++ b/src/AppController.ts
@@ -98,7 +98,9 @@ export class AppController {
    */
   async getAllDoneTasks(): Promise<Task[]> {
     const allTasks = await this.storage.getArchivedTasks();
-    const allDoneTasks = allTasks.filter((task) => task.isDone);
+    const allDoneTasks = allTasks.filter(
+      (task) => task.isDone && task.doneSessionId !== null && task.doneSessionId !== undefined,
+    );
     return allDoneTasks.sort((a, b) => {
       if (a.doneAt && b.doneAt) {
         return b.doneAt.getTime() - a.doneAt.getTime();


### PR DESCRIPTION
## Problem
Carry-over tasks were incorrectly appearing in the all done list.

## Solution
Updated `getAllDoneTasks()` to filter tasks by `doneSessionId`. Carry-over tasks have `doneSessionId = null`, so they are now excluded from the all done list.

## Changes
- Modified `AppController.getAllDoneTasks()` to check for non-null `doneSessionId`
- Added explicit `doneSessionId = null` in `carryOverTask()` for clarity

/close #6 